### PR TITLE
correcting s3_files

### DIFF
--- a/iac/s3_files.tf
+++ b/iac/s3_files.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket_object" "codigo_spark" {
+resource "aws_s3_bucket_object" "codigo_spark_mateus" {
   bucket = aws_s3_bucket.dl.id
   key    = "emr-code/pyspark/job_spark_from_tf.py"
   acl    = "private"


### PR DESCRIPTION
╷
│ Error: Duplicate resource "aws_s3_bucket_object" configuration
│ 
│   on s3_files.tf line 1:
│    1: resource "aws_s3_bucket_object" "codigo_spark" {
│ 
│ A aws_s3_bucket_object resource named "codigo_spark" was already declared
│ at s3_file.tf:1,1-47. Resource names must be unique per type in each
│ module.



The bucket already exists, so changed the name codigo_spark to codigo_spark_mateus